### PR TITLE
docs: clarify time field sanitization comment

### DIFF
--- a/src/shared/sanitizers.ts
+++ b/src/shared/sanitizers.ts
@@ -146,11 +146,11 @@ export function sanitizeEventData(eventData: Partial<CalendarEvent>): Partial<Ca
     }
   }
   
-  // Copy time fields if they exist and are objects (no sanitization needed for API objects)
+  // Sanitize time fields if they exist and are objects using sanitizeEventDateTime
   if (eventData.start && typeof eventData.start === 'object') {
     sanitized.start = sanitizeEventDateTime(eventData.start);
   }
-  
+
   if (eventData.end && typeof eventData.end === 'object') {
     sanitized.end = sanitizeEventDateTime(eventData.end);
   }


### PR DESCRIPTION
## Summary
- clarify that start and end fields are sanitized via `sanitizeEventDateTime`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab51205d58832a9f37cb35639e7f2d