### PR TITLE
Fix truncate handling for small maxLength values

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -231,12 +231,18 @@ export function capitalize(text: string): string {
 }
 
 /**
- * Truncates text to a specified length and adds ellipsis if needed
+ * Truncates text to a specified length and adds ellipsis if needed.
+ * For very small limits (≤3), returns the substring without an ellipsis.
  */
 export function truncate(text: string, maxLength: number): string {
   if (!text || text.length <= maxLength) {
     return text;
   }
+
+  if (maxLength <= 3) {
+    return text.substring(0, maxLength);
+  }
+
   return text.substring(0, maxLength - 3) + '...';
 }
 

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -205,6 +205,12 @@ describe('truncate', () => {
     expect(truncate('Short', 10)).toBe('Short');
     expect(truncate('', 5)).toBe('');
   });
+
+  it('should handle very small maxLength values', () => {
+    expect(truncate('Hello', 3)).toBe('Hel');
+    expect(truncate('Hello', 2)).toBe('He');
+    expect(truncate('Hello', 0)).toBe('');
+  });
 });
 
 describe('createId', () => {


### PR DESCRIPTION
## Summary
- handle `maxLength <= 3` in `truncate` without adding ellipsis
- test `truncate` for edge cases with very small `maxLength`
- document small `truncate` limits in code comment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab50242104832aba9379c814de1196