### PR TITLE
ci: add GitHub Actions workflow (typecheck, test, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Type-check, Test & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build extension
+        run: npm run build


### PR DESCRIPTION
## Summary

The repository had no continuous integration. This adds a GitHub Actions workflow that runs the project's existing checks on every push and pull request to `main`:

- `npm run typecheck` — `tsc --noEmit`
- `npm test` — Jest suite
- `npm run build` — `tsc` + esbuild bundling of the background/content/options scripts

## Notes

- Uses Node 20 (matches `@types/node@^20`).
- Verified locally: `npm ci`, `npm run typecheck`, `npm test` (65 passing), and `npm run build` all succeed.
- Workflow YAML validated with a parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)