### PR TITLE
test: add coverage for event-duplicator, birthday-handler, and event-extractor

### DIFF
--- a/tests/unit/birthday-handler.test.ts
+++ b/tests/unit/birthday-handler.test.ts
@@ -1,0 +1,322 @@
+// Tests for BirthdayEventHandler
+//
+// Coverage is organized by the seven review categories:
+// Security, Performance, Retry, Unit, Integration, Functional, Frame.
+
+import { BirthdayEventHandler } from '../../src/background/services/birthday-handler';
+import { CalendarApiClient } from '../../src/background/api/calendar-api';
+import { CalendarEvent, CalendarListItem, EventInfo } from '../../src/shared/types';
+import { BIRTHDAY_CONFIG } from '../../src/shared/constants';
+
+// A minimal typed mock of the CalendarApiClient surface the handler relies on.
+function createMockApiClient(): jest.Mocked<
+  Pick<CalendarApiClient, 'getCalendarList' | 'searchEvents'>
+> {
+  return {
+    getCalendarList: jest.fn(),
+    searchEvents: jest.fn(),
+  };
+}
+
+const primaryCalendar: CalendarListItem = {
+  id: 'primary',
+  summary: 'Primary Calendar',
+  accessRole: 'owner',
+  primary: true,
+};
+
+const workCalendar: CalendarListItem = {
+  id: 'work@company.com',
+  summary: 'Work Calendar',
+  accessRole: 'writer',
+};
+
+function birthdayEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: '2023_BIRTHDAY_john_doe',
+    summary: "John's Birthday",
+    start: { date: '2020-03-15' },
+    end: { date: '2020-03-16' },
+    ...overrides,
+  };
+}
+
+describe('BirthdayEventHandler', () => {
+  let api: ReturnType<typeof createMockApiClient>;
+  let handler: BirthdayEventHandler;
+
+  beforeEach(() => {
+    api = createMockApiClient();
+    handler = new BirthdayEventHandler(api as unknown as CalendarApiClient);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Security
+  // ---------------------------------------------------------------------------
+  describe('Security', () => {
+    it('rejects an invalid primary calendar id before querying events', async () => {
+      const badPrimary: CalendarListItem = {
+        id: 'not a valid id <script>',
+        summary: 'Evil',
+        accessRole: 'owner',
+        primary: true,
+      };
+      api.getCalendarList.mockResolvedValue([badPrimary]);
+
+      const result = await handler.findBirthdayEvent({ eventId: '2023_BIRTHDAY_x' });
+
+      expect(result).toBeNull();
+      // Must not attempt an event search against an unvalidated calendar id.
+      expect(api.searchEvents).not.toHaveBeenCalled();
+    });
+
+    it('validateBirthdayEvent rejects events without a usable summary', () => {
+      expect(
+        handler.validateBirthdayEvent(birthdayEvent({ summary: '   ' })),
+      ).toBe(false);
+    });
+
+    it('matchByTitle does not match when the summary is empty (no accidental broad match)', async () => {
+      api.getCalendarList.mockResolvedValue([primaryCalendar]);
+      // Event with no id match and empty summary should not be returned via title.
+      api.searchEvents.mockResolvedValue([
+        birthdayEvent({ id: 'unrelated_id', summary: '' }),
+      ]);
+
+      const result = await handler.findBirthdayEvent({
+        eventId: 'different_id',
+        title: 'John',
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Performance
+  // ---------------------------------------------------------------------------
+  describe('Performance', () => {
+    it('bounds the birthday search with a maxResults cap', async () => {
+      api.getCalendarList.mockResolvedValue([primaryCalendar]);
+      api.searchEvents.mockResolvedValue([]);
+
+      await handler.findBirthdayEvent({ eventId: '2023_BIRTHDAY_x' });
+
+      expect(api.searchEvents).toHaveBeenCalledWith('primary', {
+        eventTypes: 'birthday',
+        maxResults: 50,
+      });
+    });
+
+    it('only searches the primary calendar, not every calendar', async () => {
+      api.getCalendarList.mockResolvedValue([workCalendar, primaryCalendar]);
+      api.searchEvents.mockResolvedValue([birthdayEvent()]);
+
+      await handler.findBirthdayEvent({ eventId: '2023_BIRTHDAY_john_doe' });
+
+      expect(api.searchEvents).toHaveBeenCalledTimes(1);
+      expect(api.searchEvents).toHaveBeenCalledWith('primary', expect.anything());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Retry
+  // ---------------------------------------------------------------------------
+  describe('Retry', () => {
+    // Network-level retry/backoff lives in CalendarApiClient (RETRY_CONFIG) and
+    // is out of scope for this handler. The handler's contract is to degrade
+    // gracefully rather than throw when the API layer surfaces an error.
+    it('returns null (does not throw) when the calendar list lookup fails', async () => {
+      api.getCalendarList.mockRejectedValue(new Error('network error'));
+
+      await expect(
+        handler.findBirthdayEvent({ eventId: '2023_BIRTHDAY_x' }),
+      ).resolves.toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unit
+  // ---------------------------------------------------------------------------
+  describe('Unit', () => {
+    describe('detectBirthdayEvent (static)', () => {
+      it('detects birthday by event id pattern', () => {
+        expect(
+          BirthdayEventHandler.detectBirthdayEvent({ eventId: 'abc_BIRTHDAY_def' }),
+        ).toBe(true);
+      });
+
+      it('detects birthday by calendar name pattern', () => {
+        expect(
+          BirthdayEventHandler.detectBirthdayEvent({
+            eventId: 'plain',
+            calendarName: 'My Birthday Calendar',
+          }),
+        ).toBe(true);
+      });
+
+      it('detects birthday from DOM content', () => {
+        expect(
+          BirthdayEventHandler.detectBirthdayEvent(
+            { eventId: 'plain' },
+            'Some Birthday text here',
+          ),
+        ).toBe(true);
+      });
+
+      it('detects birthday from the title', () => {
+        expect(
+          BirthdayEventHandler.detectBirthdayEvent({
+            eventId: 'plain',
+            title: "Alice's Birthday",
+          }),
+        ).toBe(true);
+      });
+
+      it('returns false for a non-birthday event', () => {
+        expect(
+          BirthdayEventHandler.detectBirthdayEvent({
+            eventId: 'meeting_123',
+            title: 'Team Sync',
+            calendarName: 'Work',
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe('validateBirthdayEvent', () => {
+      it('accepts a well-formed event', () => {
+        expect(handler.validateBirthdayEvent(birthdayEvent())).toBe(true);
+      });
+
+      it('rejects an event missing start or end', () => {
+        expect(
+          handler.validateBirthdayEvent({
+            id: 'x',
+            summary: 'Birthday',
+            start: { date: '2020-01-01' },
+          } as CalendarEvent),
+        ).toBe(false);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Integration
+  // ---------------------------------------------------------------------------
+  describe('Integration', () => {
+    it('finds a birthday event by direct id match in the primary calendar', async () => {
+      const evt = birthdayEvent();
+      api.getCalendarList.mockResolvedValue([workCalendar, primaryCalendar]);
+      api.searchEvents.mockResolvedValue([evt]);
+
+      const result = await handler.findBirthdayEvent({
+        eventId: '2023_BIRTHDAY_john_doe',
+      });
+
+      expect(result).toEqual(evt);
+    });
+
+    it('falls back to matching a birthday event by title', async () => {
+      const evt = birthdayEvent({ id: 'server_side_id', summary: "John's Birthday" });
+      api.getCalendarList.mockResolvedValue([primaryCalendar]);
+      api.searchEvents.mockResolvedValue([evt]);
+
+      const result = await handler.findBirthdayEvent({
+        eventId: 'client_side_id',
+        title: "John's Birthday",
+      });
+
+      expect(result).toEqual(evt);
+    });
+
+    it('returns null when no primary calendar exists', async () => {
+      api.getCalendarList.mockResolvedValue([workCalendar]);
+
+      const result = await handler.findBirthdayEvent({ eventId: '2023_BIRTHDAY_x' });
+
+      expect(result).toBeNull();
+      expect(api.searchEvents).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the search yields no events', async () => {
+      api.getCalendarList.mockResolvedValue([primaryCalendar]);
+      api.searchEvents.mockResolvedValue([]);
+
+      const result = await handler.findBirthdayEvent({ eventId: '2023_BIRTHDAY_x' });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Functional
+  // ---------------------------------------------------------------------------
+  describe('Functional', () => {
+    it('creates a duplicate with a default yearly recurrence rule', () => {
+      const original = birthdayEvent();
+      const duplicate = handler.createBirthdayDuplicate(original, {
+        eventId: original.id,
+      });
+
+      expect(duplicate.recurrence).toEqual([
+        BIRTHDAY_CONFIG.RECURRENCE_RULES.YEARLY,
+      ]);
+      expect(duplicate.description).toContain(
+        BIRTHDAY_CONFIG.DESCRIPTION_SUFFIX,
+      );
+      expect(duplicate.summary).toBe("John's Birthday");
+    });
+
+    it('uses the leap-year rule for a February 29 birthday', () => {
+      const original = birthdayEvent({ start: { date: '2020-02-29' } });
+      const duplicate = handler.createBirthdayDuplicate(original, {
+        eventId: original.id,
+      });
+
+      expect(duplicate.recurrence).toEqual([
+        BIRTHDAY_CONFIG.RECURRENCE_RULES.LEAP_YEAR_FEB29,
+      ]);
+    });
+
+    it('preserves an existing recurrence rule for non-leap birthdays', () => {
+      const original = birthdayEvent({ recurrence: ['RRULE:FREQ=YEARLY;COUNT=5'] });
+      const duplicate = handler.createBirthdayDuplicate(original, {
+        eventId: original.id,
+      });
+
+      expect(duplicate.recurrence).toEqual(['RRULE:FREQ=YEARLY;COUNT=5']);
+    });
+
+    it('appends the birthday suffix only once', () => {
+      const original = birthdayEvent({
+        description: `Party time\n\n${BIRTHDAY_CONFIG.DESCRIPTION_SUFFIX}`,
+      });
+      const duplicate = handler.createBirthdayDuplicate(original, {
+        eventId: original.id,
+      });
+
+      const occurrences = duplicate.description!.split(
+        BIRTHDAY_CONFIG.DESCRIPTION_SUFFIX,
+      ).length - 1;
+      expect(occurrences).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Frame
+  // ---------------------------------------------------------------------------
+  describe('Frame', () => {
+    // The handler has no DOM/UI surface of its own; the framework-adjacent
+    // entry point is the static detector that also accepts raw DOM text.
+    it('detects a birthday from DOM-sourced content passed by the content script', () => {
+      const eventInfo: EventInfo = { eventId: 'plain_id' };
+      expect(
+        BirthdayEventHandler.detectBirthdayEvent(
+          eventInfo,
+          '<div>Happy BIRTHDAY!</div>',
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/tests/unit/event-duplicator.test.ts
+++ b/tests/unit/event-duplicator.test.ts
@@ -1,0 +1,274 @@
+// Tests for EventDuplicator
+//
+// Coverage is organized by the seven review categories:
+// Security, Performance, Retry, Unit, Integration, Functional, Frame.
+
+import { EventDuplicator } from '../../src/background/services/event-duplicator';
+import { BirthdayEventHandler } from '../../src/background/services/birthday-handler';
+import { CalendarApiClient } from '../../src/background/api/calendar-api';
+import {
+  CalendarEvent,
+  CalendarListItem,
+  ValidationError,
+} from '../../src/shared/types';
+import { STORAGE_KEYS, BIRTHDAY_CONFIG } from '../../src/shared/constants';
+
+type ApiSurface = Pick<
+  CalendarApiClient,
+  'getCalendarList' | 'getEvent' | 'searchEvents' | 'createEvent'
+>;
+
+function createMockApiClient(): jest.Mocked<ApiSurface> {
+  return {
+    getCalendarList: jest.fn(),
+    getEvent: jest.fn(),
+    searchEvents: jest.fn(),
+    createEvent: jest.fn(),
+  };
+}
+
+const DEST = 'dest@example.com';
+
+const workCalendar: CalendarListItem = {
+  id: 'work@company.com',
+  summary: 'Work Calendar',
+  accessRole: 'writer',
+};
+
+const originalEvent: CalendarEvent = {
+  id: 'evt_123',
+  summary: 'Team Meeting',
+  description: 'Weekly sync',
+  location: 'Room A',
+  start: { dateTime: '2023-12-25T10:00:00-05:00' },
+  end: { dateTime: '2023-12-25T11:00:00-05:00' },
+};
+
+function setDestination(id: string | undefined): void {
+  (chrome.storage.sync.get as jest.Mock).mockResolvedValue(
+    id === undefined ? {} : { [STORAGE_KEYS.SELECTED_CALENDAR_ID]: id },
+  );
+}
+
+describe('EventDuplicator', () => {
+  let api: jest.Mocked<ApiSurface>;
+  let duplicator: EventDuplicator;
+
+  beforeEach(() => {
+    api = createMockApiClient();
+    duplicator = new EventDuplicator(api as unknown as CalendarApiClient);
+    api.createEvent.mockResolvedValue({ ...originalEvent, id: 'new_event_123' });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Security
+  // ---------------------------------------------------------------------------
+  describe('Security', () => {
+    it('rejects an event id containing dangerous characters and never calls the API', async () => {
+      setDestination(DEST);
+
+      await expect(
+        duplicator.duplicateEvent({ eventId: 'evt<script>' }),
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(api.createEvent).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed destination calendar id from storage', async () => {
+      setDestination('not-a-calendar-id');
+
+      await expect(
+        duplicator.duplicateEvent({ eventId: 'evt_123' }),
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(api.createEvent).not.toHaveBeenCalled();
+    });
+
+    it('sanitizes copied event data before it reaches the API', async () => {
+      setDestination(DEST);
+      api.getEvent.mockResolvedValue({
+        ...originalEvent,
+        summary: 'Meeting <b>bold</b> & "quoted"',
+      });
+
+      await duplicator.duplicateEvent({
+        eventId: 'evt_123',
+        calendarId: workCalendar.id,
+      });
+
+      const sentSummary = (api.createEvent.mock.calls[0]![1] as CalendarEvent)
+        .summary as string;
+      expect(sentSummary).not.toContain('<b>');
+      expect(sentSummary).toContain('&amp;');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Performance
+  // ---------------------------------------------------------------------------
+  describe('Performance', () => {
+    it('stops searching calendars as soon as the event is found (no wasted lookups)', async () => {
+      setDestination(DEST);
+      // No calendarId/calendarName -> falls through to searchAllCalendars.
+      api.getCalendarList.mockResolvedValue([
+        workCalendar,
+        { id: 'other@company.com', summary: 'Other', accessRole: 'writer' },
+        { id: 'third@company.com', summary: 'Third', accessRole: 'writer' },
+      ]);
+      // Resolves on the very first calendar.
+      api.getEvent.mockResolvedValue(originalEvent);
+
+      await duplicator.duplicateEvent({ eventId: 'evt_123' });
+
+      // Only the first calendar should have been probed.
+      expect(api.getEvent).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Retry
+  // ---------------------------------------------------------------------------
+  describe('Retry', () => {
+    // HTTP-level retry/backoff is owned by CalendarApiClient. Here we verify the
+    // duplicator's own fallback: when a space-delimited event id fails, it
+    // retries with the leading token.
+    it('retries with the parsed event id when the full id lookup fails', async () => {
+      setDestination(DEST);
+      api.getEvent
+        .mockRejectedValueOnce(new Error('404 not found'))
+        .mockResolvedValueOnce(originalEvent);
+
+      await duplicator.duplicateEvent({
+        eventId: 'evt_123 extra-token',
+        calendarId: workCalendar.id,
+      });
+
+      expect(api.getEvent).toHaveBeenCalledTimes(2);
+      expect(api.getEvent).toHaveBeenNthCalledWith(2, workCalendar.id, 'evt_123', true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unit
+  // ---------------------------------------------------------------------------
+  describe('Unit', () => {
+    it('copies core fields from the original event into the duplicate', async () => {
+      setDestination(DEST);
+      api.getEvent.mockResolvedValue(originalEvent);
+
+      await duplicator.duplicateEvent({
+        eventId: 'evt_123',
+        calendarId: workCalendar.id,
+      });
+
+      const [calId, payload] = api.createEvent.mock.calls[0]!;
+      expect(calId).toBe(DEST);
+      expect(payload).toMatchObject({
+        summary: 'Team Meeting',
+        location: 'Room A',
+        start: { dateTime: '2023-12-25T10:00:00-05:00' },
+      });
+    });
+
+    it('defaults to a fresh BirthdayEventHandler when none is injected', () => {
+      const d = new EventDuplicator(api as unknown as CalendarApiClient);
+      expect(d).toBeInstanceOf(EventDuplicator);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Integration
+  // ---------------------------------------------------------------------------
+  describe('Integration', () => {
+    it('duplicates a regular event end to end and returns the created event', async () => {
+      setDestination(DEST);
+      api.getEvent.mockResolvedValue(originalEvent);
+
+      const result = await duplicator.duplicateEvent({
+        eventId: 'evt_123',
+        calendarId: workCalendar.id,
+      });
+
+      expect(api.getEvent).toHaveBeenCalledWith(workCalendar.id, 'evt_123', true);
+      expect(result.id).toBe('new_event_123');
+    });
+
+    it('collaborates with the real BirthdayEventHandler for birthday events', async () => {
+      setDestination(DEST);
+      const handler = new BirthdayEventHandler(api as unknown as CalendarApiClient);
+      duplicator = new EventDuplicator(api as unknown as CalendarApiClient, handler);
+
+      api.getCalendarList.mockResolvedValue([
+        { id: 'primary', summary: 'Primary', accessRole: 'owner', primary: true },
+      ]);
+      api.searchEvents.mockResolvedValue([
+        {
+          id: '2023_BIRTHDAY_amy',
+          summary: "Amy's Birthday",
+          start: { date: '2020-06-01' },
+          end: { date: '2020-06-02' },
+        },
+      ]);
+
+      await duplicator.duplicateEvent({
+        eventId: '2023_BIRTHDAY_amy',
+        isBirthdayEvent: true,
+      });
+
+      const payload = api.createEvent.mock.calls[0]![1] as CalendarEvent;
+      expect(payload.recurrence).toEqual([
+        BIRTHDAY_CONFIG.RECURRENCE_RULES.YEARLY,
+      ]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Functional
+  // ---------------------------------------------------------------------------
+  describe('Functional', () => {
+    it('throws when no destination calendar is configured', async () => {
+      setDestination(undefined);
+
+      await expect(
+        duplicator.duplicateEvent({ eventId: 'evt_123' }),
+      ).rejects.toMatchObject({ code: 'NO_DESTINATION_CALENDAR' });
+    });
+
+    it('refuses to duplicate an event already in the destination calendar', async () => {
+      setDestination(DEST);
+
+      await expect(
+        duplicator.duplicateEvent({ eventId: 'evt_123', calendarId: DEST }),
+      ).rejects.toMatchObject({ code: 'ALREADY_IN_DESTINATION' });
+    });
+
+    it('throws EVENT_NOT_FOUND when the original cannot be located anywhere', async () => {
+      setDestination(DEST);
+      api.getEvent.mockRejectedValue(new Error('404'));
+      api.getCalendarList.mockResolvedValue([workCalendar]);
+
+      await expect(
+        duplicator.duplicateEvent({ eventId: 'evt_123', calendarId: workCalendar.id }),
+      ).rejects.toMatchObject({ code: 'EVENT_NOT_FOUND' });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Frame
+  // ---------------------------------------------------------------------------
+  describe('Frame', () => {
+    it('reads the selected calendar from chrome.storage.sync', async () => {
+      setDestination(DEST);
+      api.getEvent.mockResolvedValue(originalEvent);
+
+      await duplicator.duplicateEvent({
+        eventId: 'evt_123',
+        calendarId: workCalendar.id,
+      });
+
+      expect(chrome.storage.sync.get).toHaveBeenCalledWith([
+        STORAGE_KEYS.SELECTED_CALENDAR_ID,
+      ]);
+    });
+  });
+});

--- a/tests/unit/event-extractor.test.ts
+++ b/tests/unit/event-extractor.test.ts
@@ -1,0 +1,254 @@
+// Tests for EventExtractor
+//
+// Coverage is organized by the seven review categories:
+// Security, Performance, Retry, Unit, Integration, Functional, Frame.
+//
+// The DOM is built inline (mirroring the real Google Calendar popup structure
+// the extractor reads) so these tests are fully self-contained.
+
+import { EventExtractor } from '../../src/content/extractors/event-extractor';
+
+interface DialogOptions {
+  eventId?: string;
+  title?: string;
+  time?: string;
+  location?: string;
+  description?: string;
+  calendarName?: string;
+  calendarId?: string;
+  isBirthday?: boolean;
+}
+
+function buildDialog(options: DialogOptions = {}): HTMLElement {
+  const dialog = document.createElement('div');
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('jsname', 'ssXDle');
+
+  if (options.eventId) {
+    dialog.setAttribute('data-eventid', options.eventId);
+  }
+
+  if (options.title) {
+    const el = document.createElement('h2');
+    el.id = 'rAECCd';
+    el.textContent = options.title;
+    dialog.appendChild(el);
+  }
+
+  if (options.time) {
+    const el = document.createElement('div');
+    el.className = 'AzuXid';
+    el.textContent = options.time;
+    dialog.appendChild(el);
+  }
+
+  if (options.location) {
+    const el = document.createElement('div');
+    el.id = 'xDetDlgLoc';
+    el.textContent = options.location;
+    dialog.appendChild(el);
+  }
+
+  if (options.description) {
+    const el = document.createElement('div');
+    el.id = 'xDetDlgDesc';
+    el.textContent = `Description: ${options.description}`;
+    dialog.appendChild(el);
+  }
+
+  if (options.calendarName || options.calendarId) {
+    const el = document.createElement('div');
+    el.id = 'xDetDlgCal';
+    const dataText =
+      options.calendarName && options.calendarId
+        ? `${options.calendarName} – ${options.calendarId}`
+        : options.calendarName || options.calendarId || '';
+    el.setAttribute('data-text', dataText);
+    dialog.appendChild(el);
+  }
+
+  if (options.isBirthday) {
+    dialog.appendChild(document.createTextNode(' birthday celebration'));
+  }
+
+  return dialog;
+}
+
+function regularDialog(): HTMLElement {
+  return buildDialog({
+    eventId: 'regular_event_123',
+    title: 'Team Meeting',
+    time: '2:00 PM - 3:00 PM',
+    location: 'Conference Room A',
+    description: 'Weekly team sync meeting',
+    calendarName: 'Work Calendar',
+    calendarId: 'work@company.com',
+  });
+}
+
+function birthdayDialog(): HTMLElement {
+  return buildDialog({
+    eventId: '2023_BIRTHDAY_john_doe',
+    title: "John's Birthday",
+    time: 'All day',
+    calendarName: 'Birthday Calendar',
+    calendarId: 'contacts@group.calendar.google.com',
+    isBirthday: true,
+  });
+}
+
+function minimalDialog(): HTMLElement {
+  return buildDialog({ eventId: 'minimal_event_789' });
+}
+
+describe('EventExtractor', () => {
+  let extractor: EventExtractor;
+
+  beforeEach(() => {
+    extractor = new EventExtractor();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Security
+  // ---------------------------------------------------------------------------
+  describe('Security', () => {
+    it('escapes HTML in the extracted title (no raw markup passes through)', () => {
+      const info = extractor.extractEventInfo(
+        buildDialog({ eventId: 'evt_secure', title: '<script>alert(1)</script>Meeting' }),
+      );
+
+      expect(info.title).not.toContain('<script>');
+      expect(info.title).toContain('&lt;script&gt;');
+    });
+
+    it('escapes dangerous characters in the extracted description', () => {
+      const info = extractor.extractEventInfo(
+        buildDialog({ eventId: 'evt_secure2', description: 'a & b <img src=x>' }),
+      );
+
+      expect(info.description).toContain('&amp;');
+      expect(info.description).not.toContain('<img');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Performance
+  // ---------------------------------------------------------------------------
+  describe('Performance', () => {
+    // Extraction is a bounded, single-pass read over a small popup subtree with
+    // no network or loops of concern, so there is no dedicated performance path
+    // to exercise. We assert the operation is a deterministic, side-effect-free
+    // read by confirming repeated extraction yields identical output.
+    it('produces identical results on repeated extraction (pure read)', () => {
+      const dialog = regularDialog();
+      expect(extractor.extractEventInfo(dialog)).toEqual(
+        extractor.extractEventInfo(dialog),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Retry
+  // ---------------------------------------------------------------------------
+  describe('Retry', () => {
+    // The extractor performs no I/O, so there is no retry behavior to test.
+    // It degrades gracefully on missing data instead (covered under Unit).
+    it('is not applicable — extraction performs no I/O', () => {
+      expect(true).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unit
+  // ---------------------------------------------------------------------------
+  describe('Unit', () => {
+    it('extracts all fields from a fully-populated dialog', () => {
+      const info = extractor.extractEventInfo(regularDialog());
+
+      expect(info.eventId).toBe('regular_event_123');
+      expect(info.title).toBe('Team Meeting');
+      expect(info.time).toBe('2:00 PM - 3:00 PM');
+      expect(info.location).toBe('Conference Room A');
+      expect(info.calendarName).toBe('Work Calendar');
+      expect(info.calendarId).toBe('work@company.com');
+      expect(info.isBirthdayEvent).toBe(false);
+    });
+
+    it('strips the "Description:" prefix from the description', () => {
+      const info = extractor.extractEventInfo(regularDialog());
+      expect(info.description).toBe('Weekly team sync meeting');
+    });
+
+    it('returns empty strings for fields absent from a minimal dialog', () => {
+      const info = extractor.extractEventInfo(minimalDialog());
+
+      expect(info.eventId).toBe('minimal_event_789');
+      expect(info.title).toBe('');
+      expect(info.time).toBe('');
+      expect(info.location).toBe('');
+      expect(info.calendarName).toBeUndefined();
+      expect(info.calendarId).toBeUndefined();
+    });
+
+    it('returns an empty event id when none is present in the DOM', () => {
+      const bare = document.createElement('div');
+      bare.setAttribute('role', 'dialog');
+      expect(extractor.extractEventInfo(bare).eventId).toBe('');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Integration
+  // ---------------------------------------------------------------------------
+  describe('Integration', () => {
+    it('parses the calendar name and id out of a combined data-text attribute', () => {
+      const info = extractor.extractEventInfo(regularDialog());
+      expect(info.calendarName).toBe('Work Calendar');
+      expect(info.calendarId).toBe('work@company.com');
+    });
+
+    it('extracts a coherent EventInfo object from a birthday dialog', () => {
+      const info = extractor.extractEventInfo(birthdayDialog());
+
+      expect(info.eventId).toBe('2023_BIRTHDAY_john_doe');
+      // sanitizeText escapes the apostrophe (' -> &#x27;).
+      expect(info.title).toBe('John&#x27;s Birthday');
+      expect(info.isBirthdayEvent).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Functional
+  // ---------------------------------------------------------------------------
+  describe('Functional', () => {
+    it('flags birthday events via DOM indicators', () => {
+      expect(extractor.extractEventInfo(birthdayDialog()).isBirthdayEvent).toBe(true);
+    });
+
+    it('does not flag a regular event as a birthday', () => {
+      expect(extractor.extractEventInfo(regularDialog()).isBirthdayEvent).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Frame
+  // ---------------------------------------------------------------------------
+  describe('Frame', () => {
+    it('decodes a base64-encoded event id read from a DOM element', () => {
+      const encoded = btoa('event_abc_123');
+      const dialog = document.createElement('div');
+      dialog.setAttribute('role', 'dialog');
+
+      const idHost = document.createElement('div');
+      idHost.id = 'xDetDlg';
+      idHost.setAttribute('data-eventid', encoded);
+      dialog.appendChild(idHost);
+
+      expect(extractor.extractEventInfo(dialog).eventId).toBe('event_abc_123');
+    });
+
+    it('reads the event id from the popup element itself when no child carries it', () => {
+      expect(extractor.extractEventInfo(minimalDialog()).eventId).toBe('minimal_event_789');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three core modules previously had no direct test coverage. This adds Jest suites for each, using the existing `tests/mocks` chrome-api surface and building DOM inline so the change is purely additive.

- **`src/background/services/event-duplicator.ts`** — validation/sanitization guards, calendar-search early exit, space-delimited event-id fallback, `chrome.storage` integration, birthday-handler collaboration, and the `NO_DESTINATION_CALENDAR` / `ALREADY_IN_DESTINATION` / `EVENT_NOT_FOUND` error paths.
- **`src/background/services/birthday-handler.ts`** — static birthday detection, event validation, default yearly + leap-year (Feb 29) recurrence, primary-calendar search, and id/title matching.
- **`src/content/extractors/event-extractor.ts`** — field extraction, HTML escaping, `Description:` prefix stripping, calendar `data-text` parsing, and base64 event-id decoding.

## Test categories

Each suite is organized by the seven review categories — **Security, Performance, Retry, Unit, Integration, Functional, Frame**. Where a category has no applicable surface for a module (e.g. Retry/Performance for the pure DOM extractor — network retry/backoff lives in `CalendarApiClient`), it carries an explicit placeholder test with a comment explaining why.

## Verification

- `npm test` → **114 passing** (65 existing + 49 new).
- `npm run typecheck` and `npm run build` remain green.
- No source files touched; only new test files added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)